### PR TITLE
Arpa 10 add v2xconversion repo to platform

### DIFF
--- a/ros-conversion/v2x-ros-conversion/CMakeLists.txt
+++ b/ros-conversion/v2x-ros-conversion/CMakeLists.txt
@@ -15,11 +15,9 @@ cmake_minimum_required(VERSION 3.5)
 project(v2x-ros-conversion)
 
 find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(2)
 carma_package()
 
-find_package(ros_environment REQUIRED)
-
-set(ROS_VERSION $ENV{ROS_VERSION})
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()

--- a/ros-conversion/v2x-ros-conversion/CMakeLists.txt
+++ b/ros-conversion/v2x-ros-conversion/CMakeLists.txt
@@ -18,6 +18,9 @@ find_package(carma_cmake_common REQUIRED)
 carma_check_ros_version(2)
 carma_package()
 
+find_package(ros_environment REQUIRED)
+
+set(ROS_VERSION $ENV{ROS_VERSION})
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()

--- a/ros-conversion/v2x-ros-conversion/CMakeLists.txt
+++ b/ros-conversion/v2x-ros-conversion/CMakeLists.txt
@@ -18,10 +18,6 @@ find_package(carma_cmake_common REQUIRED)
 carma_check_ros_version(2)
 carma_package()
 
-find_package(ros_environment REQUIRED)
-
-set(ROS_VERSION $ENV{ROS_VERSION})
-
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 

--- a/ros-conversion/v2x-ros-conversion/package.xml
+++ b/ros-conversion/v2x-ros-conversion/package.xml
@@ -23,9 +23,12 @@
 
   <license>Apache 2.0</license>
 
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>carma_cmake_common</build_depend>
+  <build_depend>ament_auto_cmake</build_depend>
+
+  <depend>cpp_message</depend>
+  <depend>j2735_convertor</depend>
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/ros-conversion/v2x-ros-conversion/package.xml
+++ b/ros-conversion/v2x-ros-conversion/package.xml
@@ -23,9 +23,8 @@
 
   <license>Apache 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <build_depend>carma_cmake_common</build_depend>
-  <build_depend>ament_auto_cmake</build_depend>
 
   <depend>cpp_message</depend>
   <depend>j2735_convertor</depend>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added cpp_message and j2735_converter nodes as dependencies to v2x-ros-conversion package, because this package will launch those nodes.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/ARPA-10

## Motivation and Context

To integrate v2x-ros-conversion package with carma-platform

## How Has This Been Tested?

Local integration test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
