### PR TITLE
Arpa 18 fix v2x ros conversion

### DIFF
--- a/ros-conversion/v2x-ros-conversion/CMakeLists.txt
+++ b/ros-conversion/v2x-ros-conversion/CMakeLists.txt
@@ -23,7 +23,8 @@ find_package(ros_environment REQUIRED)
 
 set(ROS_VERSION $ENV{ROS_VERSION})
 
-# ROS 2
+list(APPEND CMAKE_PREFIX_PATH "/opt/carma/cmake/")
+set(CMAKE_INSTALL_RPATH "/opt/carma/lib")
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()

--- a/ros-conversion/v2x-ros-conversion/CMakeLists.txt
+++ b/ros-conversion/v2x-ros-conversion/CMakeLists.txt
@@ -19,9 +19,7 @@ project(v2x-ros-conversion)
 find_package(carma_cmake_common REQUIRED)
 carma_package()
 
-find_package(ros_environment REQUIRED)
-
-set(ROS_VERSION $ENV{ROS_VERSION})
+carma_check_ros_version(2)
 
 list(APPEND CMAKE_PREFIX_PATH "/opt/carma/cmake/")
 set(CMAKE_INSTALL_RPATH "/opt/carma/lib")

--- a/ros-conversion/v2x-ros-conversion/package.xml
+++ b/ros-conversion/v2x-ros-conversion/package.xml
@@ -26,6 +26,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>carma_cmake_common</build_depend>
+  <build_depend>cpp_message</build_depend>
+  <build_depend>j2735_convertor</build_depend>
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

Needed to add the cpp_message and j2735_convertor to the cmakelist and package.xml for the v2x-ros-conversion node so that the v2x-ros-conversion node can launch both of the other nodes. 

## How Has This Been Tested?

Tested by confirming build works inside dev container and unit tests pass and ros is able to launch

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
