### PR TITLE
Fix/sdsm conversion

### DIFF
--- a/ros-conversion/cpp_message/src/SDSM_Message.cpp
+++ b/ros-conversion/cpp_message/src/SDSM_Message.cpp
@@ -1351,6 +1351,7 @@ namespace cpp_message
                 // PositionOffsetXYZ - offsetX
                 long offset_x = sdsm_core.objects.list.array[obj_itr]->detObjCommon.pos.offsetX;
                 if(offset_x > j3224_v2x_msgs::msg::ObjectDistance::MAX_OBJECT_DISTANCE){
+                    RCLCPP_WARN_STREAM(node_logging_->get_logger(), "SDSM offset_x: "<< offset_x);
                     RCLCPP_WARN(node_logging_->get_logger(), "Decoded SDSM object offsetX above max, setting to max");
                     offset_x = j3224_v2x_msgs::msg::ObjectDistance::MAX_OBJECT_DISTANCE;
                 }

--- a/ros-conversion/cpp_message/src/SDSM_Message.cpp
+++ b/ros-conversion/cpp_message/src/SDSM_Message.cpp
@@ -1351,7 +1351,6 @@ namespace cpp_message
                 // PositionOffsetXYZ - offsetX
                 long offset_x = sdsm_core.objects.list.array[obj_itr]->detObjCommon.pos.offsetX;
                 if(offset_x > j3224_v2x_msgs::msg::ObjectDistance::MAX_OBJECT_DISTANCE){
-                    RCLCPP_WARN_STREAM(node_logging_->get_logger(), "SDSM offset_x: "<< offset_x);
                     RCLCPP_WARN(node_logging_->get_logger(), "Decoded SDSM object offsetX above max, setting to max");
                     offset_x = j3224_v2x_msgs::msg::ObjectDistance::MAX_OBJECT_DISTANCE;
                 }

--- a/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
+++ b/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
@@ -458,13 +458,13 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::MeasurementTimeOffset& in
 
 void SDSMConvertor::convert(const j3224_v2x_msgs::msg::PositionOffsetXYZ& in_msg, carma_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {
-
     convert(in_msg.offset_x, out_msg.offset_x);
     convert(in_msg.offset_y, out_msg.offset_y);
-
+    out_msg.presence_vector |= in_msg.presence_vector;
     if(j3224_v2x_msgs::msg::PositionOffsetXYZ::HAS_OFFSET_Z & in_msg.presence_vector){
         convert(in_msg.offset_z, out_msg.offset_z);
     }
+    
 }
 void SDSMConvertor::convert(const carma_v2x_msgs::msg::PositionOffsetXYZ& in_msg, j3224_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {

--- a/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
+++ b/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
@@ -45,7 +45,7 @@ void SDSMConvertor::convert(const j3224_v2x_msgs::msg::SensorDataSharingMessage&
     // Go through the array of j3224 detected objects and convert their DetectedObjectData
     for(auto in_object : in_msg.objects.detected_object_data){
         carma_v2x_msgs::msg::DetectedObjectData out_object;
-        
+
         convert(in_object, out_object);
 
         // Add the converted object to the carma_v2x_msgs array
@@ -77,7 +77,7 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::SensorDataSharingMessage&
     // Go through the array of carma detected objects and convert their DetectedObjectData
     for(auto in_object : in_msg.objects.detected_object_data){
         j3224_v2x_msgs::msg::DetectedObjectData out_object;
-        
+
         convert(in_object, out_object);
 
         // Add the converted object to the j3224_v2x_msgs array
@@ -119,7 +119,7 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::Position3D& in_msg, j2735
     if(in_msg.elevation_exists){
         out_msg.elevation_exists = true;
         out_msg.elevation = in_msg.elevation * units::DECI_M_PER_M;
-    } 
+    }
 }
 
 
@@ -297,11 +297,11 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::VehicleHeight& in_msg, j2
 }
 
 
-void SDSMConvertor::convert(const j2735_v2x_msgs::msg::AttachmentRadius& in_msg, carma_v2x_msgs::msg::AttachmentRadius& out_msg) 
+void SDSMConvertor::convert(const j2735_v2x_msgs::msg::AttachmentRadius& in_msg, carma_v2x_msgs::msg::AttachmentRadius& out_msg)
 {
     out_msg.attachment_radius = in_msg.attachment_radius / units::DECI_M_PER_M;
 }
-void SDSMConvertor::convert(const carma_v2x_msgs::msg::AttachmentRadius& in_msg, j2735_v2x_msgs::msg::AttachmentRadius& out_msg) 
+void SDSMConvertor::convert(const carma_v2x_msgs::msg::AttachmentRadius& in_msg, j2735_v2x_msgs::msg::AttachmentRadius& out_msg)
 {
     out_msg.attachment_radius = in_msg.attachment_radius * units::DECI_M_PER_M;
 }
@@ -458,7 +458,6 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::MeasurementTimeOffset& in
 
 void SDSMConvertor::convert(const j3224_v2x_msgs::msg::PositionOffsetXYZ& in_msg, carma_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {
-    out_msg.presence_vector |= in_msg.presence_vector;
 
     if(in_msg.presence_vector){
         convert(in_msg.offset_x, out_msg.offset_x);
@@ -471,13 +470,13 @@ void SDSMConvertor::convert(const j3224_v2x_msgs::msg::PositionOffsetXYZ& in_msg
 }
 void SDSMConvertor::convert(const carma_v2x_msgs::msg::PositionOffsetXYZ& in_msg, j3224_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {
-    out_msg.presence_vector |= in_msg.presence_vector;
 
     if(in_msg.presence_vector){
         convert(in_msg.offset_x, out_msg.offset_x);
         convert(in_msg.offset_y, out_msg.offset_y);
     }
 
+    out_msg.presence_vector |= in_msg.presence_vector;
     if(carma_v2x_msgs::msg::PositionOffsetXYZ::HAS_OFFSET_Z & in_msg.presence_vector){
         convert(in_msg.offset_z, out_msg.offset_z);
     }
@@ -660,7 +659,7 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::RollRate& in_msg, j3224_v
     }
     else{
         out_msg.roll_rate = j3224_v2x_msgs::msg::RollRate::UNAVAILABLE;
-    }    
+    }
 }
 
 

--- a/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
+++ b/ros-conversion/j2735_convertor/src/sdsm_convertor.cpp
@@ -459,10 +459,8 @@ void SDSMConvertor::convert(const carma_v2x_msgs::msg::MeasurementTimeOffset& in
 void SDSMConvertor::convert(const j3224_v2x_msgs::msg::PositionOffsetXYZ& in_msg, carma_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {
 
-    if(in_msg.presence_vector){
-        convert(in_msg.offset_x, out_msg.offset_x);
-        convert(in_msg.offset_y, out_msg.offset_y);
-    }
+    convert(in_msg.offset_x, out_msg.offset_x);
+    convert(in_msg.offset_y, out_msg.offset_y);
 
     if(j3224_v2x_msgs::msg::PositionOffsetXYZ::HAS_OFFSET_Z & in_msg.presence_vector){
         convert(in_msg.offset_z, out_msg.offset_z);
@@ -471,10 +469,8 @@ void SDSMConvertor::convert(const j3224_v2x_msgs::msg::PositionOffsetXYZ& in_msg
 void SDSMConvertor::convert(const carma_v2x_msgs::msg::PositionOffsetXYZ& in_msg, j3224_v2x_msgs::msg::PositionOffsetXYZ& out_msg)
 {
 
-    if(in_msg.presence_vector){
-        convert(in_msg.offset_x, out_msg.offset_x);
-        convert(in_msg.offset_y, out_msg.offset_y);
-    }
+    convert(in_msg.offset_x, out_msg.offset_x);
+    convert(in_msg.offset_y, out_msg.offset_y);
 
     out_msg.presence_vector |= in_msg.presence_vector;
     if(carma_v2x_msgs::msg::PositionOffsetXYZ::HAS_OFFSET_Z & in_msg.presence_vector){


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix SDSM conversion optional field being incorrect.
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Found during VIP demo practice
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacfifica and SDSM from V2XHub directly (5GAA demo)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
