### PR TITLE
fix: brake applied status handling logic

### DIFF
--- a/ros-conversion/cpp_message/CMakeLists.txt
+++ b/ros-conversion/cpp_message/CMakeLists.txt
@@ -54,6 +54,7 @@ ament_auto_add_library(${node_lib} SHARED
         src/Map_Message.cpp
         src/PSM_Message.cpp
         src/SDSM_Message.cpp
+        src/Util.cpp
         )
 
 target_link_libraries(${node_lib} ::stol-j2735-${J2735_REVISION}-carma)
@@ -92,6 +93,7 @@ if(BUILD_TESTING)
                         test/test_PSM.cpp
                         test/node_test.cpp
                         test/test_SDSM.cpp
+                        test/test_util.cpp
                         )
 
   ament_target_dependencies(test_cpp_message_node ${${PROJECT_NAME}_FOUND_TEST_DEPENDS} )

--- a/ros-conversion/cpp_message/include/cpp_message/Util.h
+++ b/ros-conversion/cpp_message/include/cpp_message/Util.h
@@ -5,7 +5,6 @@
 
 namespace cpp_message{
 
-
     /// @brief Reverses the bits of a uint8_t value
     /// @param x The input value
     /// @return The value with reversed bits

--- a/ros-conversion/cpp_message/include/cpp_message/Util.h
+++ b/ros-conversion/cpp_message/include/cpp_message/Util.h
@@ -1,0 +1,17 @@
+#ifndef __CPP_MESSAGE_UTIL_H__
+#define __CPP_MESSAGE_UTIL_H__
+
+#include <cstdint>
+
+namespace cpp_message{
+
+
+    /// @brief Reverses the bits of a uint8_t value
+    /// @param x The input value
+    /// @return The value with reversed bits
+    /// @details This function is used to convert bit string (least significant bit) to ros message representation (most significant bit first). 
+    std::uint8_t reverseBitsUint8(std::uint8_t x);
+}
+
+
+#endif // __CPP_MESSAGE_UTIL_H__

--- a/ros-conversion/cpp_message/src/BSM_Message.cpp
+++ b/ros-conversion/cpp_message/src/BSM_Message.cpp
@@ -410,7 +410,7 @@ namespace cpp_message
             output.core_data.accel_set.vert = core_data_msg.accelSet.vert;
             output.core_data.accel_set.yaw_rate = core_data_msg.accelSet.yaw;
             // brake_applied_status decoding
-            // reverse bits 0b0100000 to 0b00000010
+            // reverse bits e.g. 0b0100000 to 0b00000010
             output.core_data.brakes.wheel_brakes.brake_applied_status = reverseBitsUint8(core_data_msg.brakes.wheelBrakes.buf[0]);
 
             output.core_data.brakes.traction.traction_control_status = core_data_msg.brakes.traction;
@@ -1001,11 +1001,7 @@ namespace cpp_message
         
         BrakeAppliedStatus_t brake_applied_status;
         
-        uint8_t wheel_brake[1] = {0};
-
-        // there are 3 unused bits in the end: 0b000
-        // unavailable=1, leftFront=2, leftRear=4, rightFront=8, rightRear=16 in the plain msg
-        // note: more than 1 bits can be set
+        uint8_t wheel_brake[1];
         wheel_brake[0] = reverseBitsUint8(plain_msg.core_data.brakes.wheel_brakes.brake_applied_status);
         brake_applied_status.buf = wheel_brake;
         brake_applied_status.size = 1;

--- a/ros-conversion/cpp_message/src/BSM_Message.cpp
+++ b/ros-conversion/cpp_message/src/BSM_Message.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "cpp_message/BSM_Message.h"
+#include "cpp_message/Util.h"
 
 namespace cpp_message
 {
@@ -409,24 +410,9 @@ namespace cpp_message
             output.core_data.accel_set.vert = core_data_msg.accelSet.vert;
             output.core_data.accel_set.yaw_rate = core_data_msg.accelSet.yaw;
             // brake_applied_status decoding
-            // e.g. make 0b0100000 to 0b0000100
-            uint8_t binary = core_data_msg.brakes.wheelBrakes.buf[0] >> 3;
-            unsigned int brake_applied_status_type = 4;
-            // e.g. shift the binary right until it equals to 1 (0b00000001) to determine the location of the non-zero bit
-            
-            for (int i = 0; i < 4; i ++)
-            {
-                if ((int)binary == 1) 
-                {
-                    output.core_data.brakes.wheel_brakes.brake_applied_status = brake_applied_status_type;
-                    break;
-                }
-                else
-                {
-                    brake_applied_status_type -= 1;
-                    binary = binary >> 1;
-                }
-            }
+            // reverse bits 0b0100000 to 0b00000010
+            output.core_data.brakes.wheel_brakes.brake_applied_status = reverseBitsUint8(core_data_msg.brakes.wheelBrakes.buf[0]);
+
             output.core_data.brakes.traction.traction_control_status = core_data_msg.brakes.traction;
             output.core_data.brakes.abs.anti_lock_brake_status = core_data_msg.brakes.abs;
             output.core_data.brakes.scs.stability_control_status = core_data_msg.brakes.scs;
@@ -1015,13 +1001,12 @@ namespace cpp_message
         
         BrakeAppliedStatus_t brake_applied_status;
         
-        uint8_t wheel_brake[1] = {8}; // dummy 8 value
+        uint8_t wheel_brake[1] = {0};
 
         // there are 3 unused bits in the end: 0b000
-        // which makes every possible encoded value to be multiples of 8: 0b00001000 (8), 0b00010000 (16), 0b00011000 (24) etc
-        // so num in brackets indicate the position in the bit string:
-        // unavailable: 0b10000000, leftFront: 0b01000000 etc
-        wheel_brake[0] = (char) (8 << (4 - plain_msg.core_data.brakes.wheel_brakes.brake_applied_status)); 
+        // unavailable=1, leftFront=2, leftRear=4, rightFront=8, rightRear=16 in the plain msg
+        // note: more than 1 bits can be set
+        wheel_brake[0] = reverseBitsUint8(plain_msg.core_data.brakes.wheel_brakes.brake_applied_status);
         brake_applied_status.buf = wheel_brake;
         brake_applied_status.size = 1;
         brake_applied_status.bits_unused = 3;

--- a/ros-conversion/cpp_message/src/Util.cpp
+++ b/ros-conversion/cpp_message/src/Util.cpp
@@ -1,6 +1,7 @@
 #include "cpp_message/Util.h"
 
 namespace cpp_message {
+
     std::uint8_t reverseBitsUint8(std::uint8_t x) {
         // 1. Swap adjacent 4-bit nibbles (abcd efgh -> efgh abcd)
         x = static_cast<std::uint8_t>(((x & 0xF0) >> 4) | ((x & 0x0F) << 4));

--- a/ros-conversion/cpp_message/src/Util.cpp
+++ b/ros-conversion/cpp_message/src/Util.cpp
@@ -1,0 +1,17 @@
+#include "cpp_message/Util.h"
+
+namespace cpp_message {
+    std::uint8_t reverseBitsUint8(std::uint8_t x) {
+        // 1. Swap adjacent 4-bit nibbles (abcd efgh -> efgh abcd)
+        x = static_cast<std::uint8_t>(((x & 0xF0) >> 4) | ((x & 0x0F) << 4));
+        
+        // 2. Swap adjacent 2-bit pairs (efgh abcd -> ghef cdab)
+        x = static_cast<std::uint8_t>(((x & 0xCC) >> 2) | ((x & 0x33) << 2));
+        
+        // 3. Swap adjacent single bits (ghef cdab -> hgfe dcba)
+        x = static_cast<std::uint8_t>(((x & 0xAA) >> 1) | ((x & 0x55) << 1));
+        
+        return x;
+    }
+
+}

--- a/ros-conversion/cpp_message/test/test_BSM.cpp
+++ b/ros-conversion/cpp_message/test/test_BSM.cpp
@@ -73,7 +73,9 @@ TEST(BSMTest, testEncodeBSM)
     message.core_data.sec_mark = 1;
     message.core_data.longitude = 1;
     message.core_data.accuracy.orientation = 1;
-    message.core_data.brakes.wheel_brakes.brake_applied_status = j2735_v2x_msgs::msg::BrakeAppliedStatus::RIGHT_REAR;
+    message.core_data.brakes.wheel_brakes.brake_applied_status = 0u;
+    message.core_data.brakes.wheel_brakes.brake_applied_status |= j2735_v2x_msgs::msg::BrakeAppliedStatus::LEFT_REAR;
+    message.core_data.brakes.wheel_brakes.brake_applied_status |= j2735_v2x_msgs::msg::BrakeAppliedStatus::LEFT_FRONT;
     message.core_data.brakes.traction.traction_control_status = 1;
     message.core_data.brakes.abs.anti_lock_brake_status = 1;
     message.core_data.brakes.scs.stability_control_status = 1;
@@ -128,7 +130,9 @@ TEST(BSMTest, testEncodeDecodeBSM)
     message.core_data.sec_mark = 2;
     message.core_data.longitude = 3;
     message.core_data.accuracy.orientation = 4;
-    message.core_data.brakes.wheel_brakes.brake_applied_status = j2735_v2x_msgs::msg::BrakeAppliedStatus::RIGHT_REAR;
+    message.core_data.brakes.wheel_brakes.brake_applied_status = 0u;
+    message.core_data.brakes.wheel_brakes.brake_applied_status |= j2735_v2x_msgs::msg::BrakeAppliedStatus::LEFT_REAR;
+    message.core_data.brakes.wheel_brakes.brake_applied_status |= j2735_v2x_msgs::msg::BrakeAppliedStatus::LEFT_FRONT;
     message.core_data.brakes.traction.traction_control_status = 1;
     message.core_data.brakes.abs.anti_lock_brake_status = 1;
     message.core_data.brakes.scs.stability_control_status = 1;

--- a/ros-conversion/cpp_message/test/test_util.cpp
+++ b/ros-conversion/cpp_message/test/test_util.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019-2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "cpp_message/Util.h"
+#include <bitset>
+#include <gtest/gtest.h>
+
+
+TEST(UtilTest, testReverseBitsUint8)
+{
+    // Test cases: input and expected output pairs
+    std::vector<std::pair<std::uint8_t, std::uint8_t>> test_cases = {
+        {0b00000000, 0b00000000}, // All bits 0
+        {0b11111111, 0b11111111}, // All bits 1
+        {0b10101010, 0b01010101}, // Alternating bits starting with 1
+        {0b01010101, 0b10101010}, // Alternating bits starting with 0
+        {0b11010010, 0b01001011}, // Random pattern
+        {0b00001111, 0b11110000}, // Lower half bits set
+        {0b11110000, 0b00001111}  // Upper half bits set
+    };
+
+    for (const auto& test_case : test_cases) {
+        std::uint8_t input = test_case.first;
+        std::uint8_t expected_output = test_case.second;
+        std::uint8_t actual_output = cpp_message::reverseBitsUint8(input);
+        EXPECT_EQ(actual_output, expected_output) << "Failed for input: " << std::bitset<8>(input);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details

## Description

The handling of the `brake_applied_status` (uint8 representation of a 5-bit bit string, last 3 bits unused) in the BSM script was incorrect due to the following factors:
- The code assumed the definition of the corresponding ROS message literal values take value from 0, 1, ..., 4 instead of powers of 2 (updated in this [PR](https://github.com/usdot-fhwa-stol/carma-msgs/pull/274))
- The code assumed that the only one bit can be set, which is not the case.

The new changes are as follows:
- A `Util` component that implements the `reverseBitsUint8` function, which converts between original bit string representation (e.g., 0b10000000, which corresponds to `UNAVAILABLE`, last 3 bits unused) ) to ROS representation (0b00000001, e.g., value of 1)
- The test values are updated in `test_BSM.cpp` to flip on multiple bits in `brake_applied_status`. `test_util.cpp` is added to test the `reverseBitsUint8` function.
- `CMakeList` is updated with new build target. 

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

The package is rebuilt and new and existing tests have passed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
